### PR TITLE
fix: remove yarn immutable cache for publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: install dependencies
         working-directory: "./"
-        run: yarn install --immutable --immutable-cache --mode=skip-build
+        run: yarn install
 
       - name: build
         run: yarn build:all


### PR DESCRIPTION
Incompatibility with multiple OS development